### PR TITLE
Fix `ci{` instruction

### DIFF
--- a/public/course.tsx
+++ b/public/course.tsx
@@ -386,7 +386,7 @@ function App() {
 // Let's refactor the `onClick` handler into a separate function.
 
 // Steps:
-// 1. Place your cursor at the start of the line with `<button>`.
+// 1. Place your cursor inside the `<button>` `onClick` handler function.
 // 2. Press `ci{` (change inside curly braces) to delete the content inside `{}` and enter insert mode.
 //    - This will cut the content and save it to the clipboard.
 // 4. Type `handleClick` and press `Esc`.


### PR DESCRIPTION
If we are inside a {}, ci{ cuts that block instead of the next {}, so we should do the operation inside the `onClick` handler.