### PR TITLE
change link to avoid feeling of circular navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -111,7 +111,7 @@ export default function Page() {
         <div>
           <a
             target="_blank"
-            href="https://github.com/leerob/vim-for-react-devs"
+            href="https://github.com/leerob/vim-for-react-devs?tab=readme-ov-file#prerequisites"
             className="inline-block bg-[#7aa2f7] text-[#1a1b26] font-medium px-4 py-1 rounded hover:bg-[#2ac3de] transition-colors duration-300"
           >
             Start Course


### PR DESCRIPTION
Nice course!

At first when scanning things quickly I went into a circular navigation: 

1. Go to github repo 
2. Click landing page link expecting course is on the site
3. Click on landing page "start course" going back to github repo
4. a bit confused as to where course files were.


I thought it would help to have the link go directly to the prereq section and avoid this loop for people who land first on the course from the github link 