### PR TITLE
Fixes error in `ci{` lesson

### DIFF
--- a/public/course.tsx
+++ b/public/course.tsx
@@ -411,7 +411,7 @@ function App() {
 // Let's refactor the `onClick` handler into a separate function.
 
 // Steps:
-// 1. Place your cursor at the start of the line with `<button>`.
+// 1. Place your cursor at the start of the inline arrow function on the `<button>`.
 // 2. Press `ci{` (change inside curly braces) to delete the content inside `{}` and enter insert mode.
 //    - This will cut the content and save it to the clipboard.
 // 4. Type `handleClick` and press `Esc` to exit insert mode.


### PR DESCRIPTION
Executing `ci{` at the beginning of `<button>` cuts a lot more than you want. It needs to be inside the `{}`.